### PR TITLE
recognize vehicle id parameter

### DIFF
--- a/lib/concerns/overloadable_functions.rb
+++ b/lib/concerns/overloadable_functions.rb
@@ -23,7 +23,7 @@ module OverloadableFunctions
   def compatible_characteristics?(service_chars, vehicle_chars)
     # Compatile service and vehicle
     # if the vehicle cannot serve the service due to sticky_vehicle_id
-    return false if !service_chars[:v_id].empty? && (service_chars[:v_id] & vehicle_chars[:id]).empty?
+    return false if !service_chars[:v_id].empty? && (service_chars[:v_id] & vehicle_chars[:v_id]).empty?
 
     # if the service needs a skill that the vehicle doesn't have
     return false if !(service_chars[:skills] - vehicle_chars[:skills]).empty?


### PR DESCRIPTION
Fix for : https://sentry.mapotempo.com/mapotempo/api-optimizer-prod/issues/14310/events/

Current gem does not work with sticky vehicles.