### PR TITLE
Clustering respects relations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    balanced_vrp_clustering (0.1.7)
+    balanced_vrp_clustering (0.2.0)
       awesome_print
       color-generator
       geojson2image
@@ -18,12 +18,12 @@ GEM
     ansi (1.5.0)
     anyway_config (1.4.4)
     ast (2.4.0)
-    awesome_print (1.8.0)
+    awesome_print (1.9.2)
     backport (0.3.0)
     benchmark-ips (2.7.2)
     builder (3.2.4)
     byebug (11.0.1)
-    chunky_png (1.3.12)
+    chunky_png (1.4.0)
     color-generator (0.0.4)
     concurrent-ruby (1.1.6)
     docile (1.3.2)
@@ -58,7 +58,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    oj (3.10.8)
+    oj (3.11.2)
     parallel (1.19.1)
     parser (2.7.0.4)
       ast (~> 2.4.0)
@@ -153,3 +153,6 @@ DEPENDENCIES
 
 RUBY VERSION
    ruby 2.3.3p222
+
+BUNDLED WITH
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ data_items = items.collect{ |i|
     "matrix_index": only if any matrix was provided
   }
 }
-cut_symbol = :duration # or any other unit (:unit_1, :unit_2) to be used for balancig clusters
+cut_symbol = :duration # or any other unit (:unit_1, :unit_2) to be used for balancing clusters
+related_item_indices = { shipment: [[0, 1] [2, 3]], same_route: [[4, 5]]} # Available relations are as follows
+                                                                          # LINKING_RELATIONS = %i[order same_route sequence shipment]
+                                                                          # BINDING_RELATIONS = %i[order same_route sequence]
 ratio = 1 # by default, used to over/underestimate vehicles limits
 c.logger = Logger.new(STDOUT) # for debug output
-c.build(DataSet.new(data_items: data_items), cut_symbol, ratio, options)```
+c.build(DataSet.new(data_items: data_items), cut_symbol, related_item_indices, ratio, options)```
 
 cut_symbol is the referent unit to use when balancing clusters. This unit should exist in both vehicles and data_items structures.
 ```

--- a/balanced_vrp_clustering.gemspec
+++ b/balanced_vrp_clustering.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name = 'balanced_vrp_clustering'
-  s.version = '0.1.7'
-  s.date = '2020-08-13'
-  s.summary = 'Gem to clusterize points of a given VRP.'
+  s.version = '0.2.0'
+  s.date = '2021-03-09'
+  s.summary = 'Gem for clustering points of a given VRP.'
   s.authors = 'Mapotempo'
   s.files = [
     "lib/balanced_vrp_clustering.rb",

--- a/lib/balanced_vrp_clustering.rb
+++ b/lib/balanced_vrp_clustering.rb
@@ -478,7 +478,6 @@ module Ai4r
         @clusters = Array.new(@number_of_clusters) do
           Ai4r::Data::DataSet.new data_labels: @data_set.data_labels
         end
-        @cluster_indices = Array.new(@number_of_clusters){ [] }
 
         @data_set.data_items.each{ |data_item|
           cluster_index = evaluate(data_item)
@@ -615,22 +614,6 @@ module Ai4r
 
           empty_cluster.data_items << closest[2].data_items.delete(closest[1])
         }
-      end
-
-      def eliminate_empty_clusters
-        old_clusters, old_centroids, old_cluster_indices = @clusters, @centroids, @cluster_indices
-        @clusters, @centroids, @cluster_indices = [], [], []
-        @remaining_skills = []
-        @number_of_clusters.times do |i|
-          if old_clusters[i].data_items.empty?
-            @remaining_skills << old_centroids[i][4]
-          else
-            @clusters << old_clusters[i]
-            @cluster_indices << old_cluster_indices[i]
-            @centroids << old_centroids[i]
-          end
-        end
-        @number_of_clusters = @centroids.length
       end
 
       def stop_criteria_met

--- a/lib/balanced_vrp_clustering.rb
+++ b/lib/balanced_vrp_clustering.rb
@@ -171,7 +171,6 @@ module Ai4r
         }
 
         @strict_limitations, @cut_limit = compute_limits(cut_symbol, cut_ratio, @vehicles, @data_set.data_items)
-        @remaining_skills = @vehicles.dup
 
         ### algo start ###
         @iteration = 0
@@ -561,7 +560,7 @@ module Ai4r
       end
 
       def calc_initial_centroids
-        @centroids, @old_centroids_lat_lon = [], nil
+        @centroids, @old_centroids_lat_lon, @remaining_skills = [], nil, @vehicles.dup
         if @centroid_indices.empty?
           populate_centroids('random')
         else
@@ -625,7 +624,7 @@ module Ai4r
             skills[:duration_from_and_to_depot] = item[4][:duration_from_and_to_depot][@centroids.length]
             @centroids << [item[0], item[1], item[2], Hash.new(0), skills]
 
-            available_items.delete(item)
+            do_forall_linked_items_of(item){ |linked_item| available_items.delete(linked_item) }
 
             @data_set.data_items.insert(0, @data_set.data_items.delete(item))
           end

--- a/lib/balanced_vrp_clustering.rb
+++ b/lib/balanced_vrp_clustering.rb
@@ -641,6 +641,12 @@ module Ai4r
             skills = @remaining_skills.shift
             item = @data_set.data_items[index]
 
+            # check if linked data items are assigned to different centroids
+            do_forall_linked_items_of(item){ |linked_item|
+              msg = "Centroid #{ind} is initialised with a service which has a linked service that is used to initialise centroid #{insert_at_begining.index(linked_item)}"
+              raise ArgumentError, msg if insert_at_begining.include?(linked_item)
+            }
+
             raise ArgumentError, "Centroid #{ind} is initialised with an incompatible service -- #{index}" unless @compatibility_function.call(item, [nil, nil, nil, nil, skills])
 
             skills[:matrix_index] = item[4][:matrix_index]

--- a/test/clustering_test.rb
+++ b/test/clustering_test.rb
@@ -283,4 +283,17 @@ class ClusteringTest < Tests
     expected_msg = 'Centroid 1 is initialised with a service which has a linked service that is used to initialise centroid 0'
     assert_equal expected_msg, error.message, 'Error message is changed'
   end
+
+  def test_centroid_initialisation_respects_relations
+    clusterer, data_set = Instance.two_clusters_4_items_with_matrix
+    clusterer.stub(:calc_initial_centroids, lambda{
+      10.times{
+        clusterer.send(:__minitest_stub__calc_initial_centroids)
+        assert_match(/point_[1-3]point_4/, clusterer.centroids.map{ |i| i[2] }.sort!.join)
+      }
+      return
+    }) do
+      clusterer.build(data_set, :duration, { same_route: [[0, 1, 2]] })
+    end
+  end
 end

--- a/test/clustering_test.rb
+++ b/test/clustering_test.rb
@@ -101,14 +101,14 @@ class ClusteringTest < Tests
     # the skills of the service does not exist in any of the vehicles
     clusterer, data_set, options, ratio = Instance.load_clusterer('test/fixtures/infeasible_skills.bindump')
 
-    assert clusterer.build(data_set, options[:cut_symbol], ratio, options)
+    assert clusterer.build(data_set, options[:cut_symbol], {}, ratio, options)
   end
 
   def test_division_by_nan
     clusterer, data_set, options, ratio = Instance.load_clusterer('test/fixtures/division_by_nan.bindump')
     # options[:seed] = 182581703914854297101438278871236808945
 
-    assert clusterer.build(data_set, options[:cut_symbol], ratio, options)
+    assert clusterer.build(data_set, options[:cut_symbol], {}, ratio, options)
   end
 
   def test_cluster_balance
@@ -131,7 +131,7 @@ class ClusteringTest < Tests
       while data_set.data_items.size > 100
         number_of_items_expected = data_set.data_items.size
 
-        clusterer.build(data_set, options[:cut_symbol], ratio, options)
+        clusterer.build(data_set, options[:cut_symbol], {}, ratio, options)
 
         repartition = clusterer.clusters.collect{ |c| c.data_items.size }
         puts "#{number_of_items_expected} items divided in into #{repartition}"
@@ -186,7 +186,7 @@ class ClusteringTest < Tests
     # more vehicles than data_items..
     clusterer, data_set, options, ratio = Instance.load_clusterer('test/fixtures/length_centroid.bindump')
 
-    clusterer.build(data_set, options[:cut_symbol], ratio, options)
+    clusterer.build(data_set, options[:cut_symbol], {}, ratio, options)
 
     assert_equal 2, clusterer.clusters.count{ |c| !c.data_items.empty? }, 'There are only 2 data_items, should have at most 2 non-empty clusters.'
   end
@@ -198,7 +198,7 @@ class ClusteringTest < Tests
     # TODO: we should handle these extreme cases better
     clusterer, data_set, options, ratio = Instance.load_clusterer('test/fixtures/avoid_capacities_overlap.bindump')
 
-    clusterer.build(data_set, options[:cut_symbol], ratio, options)
+    clusterer.build(data_set, options[:cut_symbol], {}, ratio, options)
 
     assert_equal 5, clusterer.clusters.count{ |c| !c.data_items.empty? }, 'There should be 5 non-empty clusters'
 
@@ -225,5 +225,32 @@ class ClusteringTest < Tests
       clusterer.geojson_dump_freq = 1
       clusterer.build(data_set, :visits)
     end
+  end
+
+  def test_a_service_cannot_appear_in_two_nonbinding_linking_relations
+    clusterer, data_set = Instance.two_clusters_4_items_with_matrix
+
+    assert_raises ArgumentError do
+      clusterer.connect_linked_items(data_set.data_items, { shipment: [[0, 1], [0, 2]] })
+    end
+  end
+
+  def test_connect_linked_items_to_eachother
+    clusterer, data_set = Instance.two_clusters_4_items_with_matrix
+
+    data_items = Marshal.load(Marshal.dump(data_set.data_items))
+    # two separate 2-loops
+    clusterer.connect_linked_items(data_items, { shipment: [[0, 1], [2, 3]] })
+    assert_equal([1, 0, 3, 2], data_items.collect{ |item| data_items.index(item[4][:linked_item]) })
+
+    data_items = Marshal.load(Marshal.dump(data_set.data_items))
+    # two merged 2-loops (one 4-loop)
+    clusterer.connect_linked_items(data_items, { shipment: [[0, 1], [2, 3]], same_route: [[0, 2]] })
+    assert_equal([1, 2, 3, 0], data_items.collect{ |item| data_items.index(item[4][:linked_item]) })
+
+    data_items = Marshal.load(Marshal.dump(data_set.data_items))
+    # one 3-loop
+    clusterer.connect_linked_items(data_items, { same_route: [[0, 1, 2]] })
+    assert_equal([1, 2, 0, nil], data_items.collect{ |item| data_items.index(item[4][:linked_item]) })
   end
 end

--- a/test/clustering_test.rb
+++ b/test/clustering_test.rb
@@ -253,4 +253,24 @@ class ClusteringTest < Tests
     clusterer.connect_linked_items(data_items, { same_route: [[0, 1, 2]] })
     assert_equal([1, 2, 0, nil], data_items.collect{ |item| data_items.index(item[4][:linked_item]) })
   end
+
+  def test_clustering_respects_relations
+    clusterer, data_set = Instance.two_clusters_4_items_with_matrix
+    clusterer.build(data_set, :duration, { shipment: [[0, 1], [2, 3]] })
+    assert_equal [%w[point_1 point_2], %w[point_3 point_4]],
+                 clusterer.clusters.collect{ |c| c.data_items.collect{ |i| i[2] }.sort! }.sort!,
+                 'Clustering should respect linking relations'
+
+    clusterer, data_set = Instance.two_clusters_4_items_with_matrix
+    clusterer.build(data_set, :duration, { shipment: [[0, 1], [2, 3]], same_route: [[0, 2]] })
+    assert_equal [[], %w[point_1 point_2 point_3 point_4]],
+                 clusterer.clusters.collect{ |c| c.data_items.collect{ |i| i[2] }.sort! }.sort!,
+                 'Clustering should respect binding relations'
+
+    clusterer, data_set = Instance.two_clusters_4_items_with_matrix
+    clusterer.build(data_set, :duration, { shipment: [[0, 1]], same_route: [[0, 2]] })
+    assert_equal [%w[point_1 point_2 point_3], %w[point_4]],
+                 clusterer.clusters.collect{ |c| c.data_items.collect{ |i| i[2] }.sort! }.sort!,
+                 'Clustering should respect relations'
+  end
 end

--- a/test/clustering_test.rb
+++ b/test/clustering_test.rb
@@ -273,4 +273,14 @@ class ClusteringTest < Tests
                  clusterer.clusters.collect{ |c| c.data_items.collect{ |i| i[2] }.sort! }.sort!,
                  'Clustering should respect relations'
   end
+
+  def test_centroid_indices_respect_relations
+    clusterer, data_set = Instance.two_clusters_4_items_with_matrix
+    clusterer.centroid_indices = [0, 1]
+    error = assert_raises ArgumentError do
+      clusterer.build(data_set, :duration, { shipment: [[0, 1]] })
+    end
+    expected_msg = 'Centroid 1 is initialised with a service which has a linked service that is used to initialise centroid 0'
+    assert_equal expected_msg, error.message, 'Error message is changed'
+  end
 end


### PR DESCRIPTION
First version doesn't contain any notion of distance to the points already assigned to the centroids. For handling P&D clustering more "correctly" this might be necessary. Will see when we have the realistic instances but this version is ready to go as it is :crossed_fingers: 